### PR TITLE
23 add project summaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,4 @@ async-recursion = "1.0.2"
 actix-web = "4.3.0"
 serde_json = "1.0.93"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
-
-
+ethers = "1.0.2"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This endpoint fetches project data from the database. It accepts a query paramet
 - `data`: Include project data in the response.
 - `project_meta_ptr`: Include project metadata pointer in the response.
 - `project_votes`: Include project votes data in the response.
+- `project_summary`: Include project summary data in the response.
 
 #### `GET /ipfs`
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -264,7 +264,6 @@ pub fn new_qf_votes(conn: &mut PgConnection, data: Vec<QfVote>) {
 
     insert_qf_votes(conn, qf_votes_data);
 
-    // insert_qf_votes1(conn, qf_votes);
 }
 
 pub async fn get_round_meta_ptr(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,35 @@ pub mod models;
 pub mod schema;
 pub mod seed;
 pub mod utils;
+
+// #[cfg(test)]
+// mod tests {
+//     use actix_web::body;
+
+//     use crate::models;
+
+//     #[test]
+//     fn it_works() {
+//         let result = 2 + 2;
+//         assert_eq!(result, 4);
+//     }
+
+//     #[test]
+//     fn project_data() {
+//         // make a request to the server
+//         // assert that the response is correct
+
+//         let url = "http://localhost:8080/project?project_id=0xc290dd8e51ac35480d9872ce4484aac23bb812c47c0567bfd4beb9113726ed11&data=true";
+
+//         let response = reqwest::blocking::get(url).unwrap();
+
+//         assert_eq!(response.status(), 200);
+
+//         let res: models::ProjectResponseData = response.json().unwrap();
+
+//         assert_eq!(
+//             res.data.unwrap().projectId,
+//             "0xc290dd8e51ac35480d9872ce4484aac23bb812c47c0567bfd4beb9113726ed11"
+//         );
+//     }
+// }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,52 +1,5 @@
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
-use grants_stack_api::{
-    database,
-    models::{
-        ProjectItem, ProjectMetaPtrItem, QfVoteItem, RoundItem, RoundMetaPtrItem,
-        RoundProjectsMetaPtrItem, VotingStrategyItem,
-    },
-    seed, utils,
-};
-use serde::{Deserialize, Serialize};
-#[derive(Clone, Deserialize, Debug)]
-struct GetRoundDataQueryParams {
-    round_id: String,
-    data: Option<bool>,
-    round_meta_ptr: Option<bool>,
-    voting_strategy: Option<bool>,
-    projects_meta_ptr: Option<bool>,
-    round_projects: Option<bool>,
-    round_votes: Option<bool>,
-}
-
-#[derive(Deserialize, Serialize, Debug)]
-struct RoundResponseData {
-    data: Option<RoundItem>,
-    round_meta_ptr: Option<RoundMetaPtrItem>,
-    voting_strategy: Option<VotingStrategyItem>,
-    projects_meta_ptr: Option<RoundProjectsMetaPtrItem>,
-    round_projects: Option<Vec<ProjectItem>>,
-    round_votes: Option<Vec<QfVoteItem>>,
-}
-#[derive(Clone, Deserialize)]
-struct GetProjectDataQueryParams {
-    project_id: String,
-    data: Option<bool>,
-    project_meta_ptr: Option<bool>,
-    project_votes: Option<bool>,
-}
-
-#[derive(Deserialize, Serialize, Debug)]
-struct ProjectResponseData {
-    data: Option<ProjectItem>,
-    project_meta_ptr: Option<ProjectMetaPtrItem>,
-    project_votes: Option<Vec<QfVoteItem>>,
-}
-
-#[derive(Deserialize)]
-struct GetIPFSQueryParams {
-    cid: Option<String>,
-}
+use grants_stack_api::{database, models, seed, utils};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -80,8 +33,8 @@ async fn seed_handler(chain_id: web::Path<u16>) -> impl Responder {
 // use ?round_id=0x01...&{data, round_meta_ptr, voting_strategy, round_projects_meta_ptr, round_projects, qf_votes}=true/false
 // multiple params can be used at once
 #[get("/round")]
-async fn get_round_handler(query: web::Query<GetRoundDataQueryParams>) -> impl Responder {
-    let mut res_data = RoundResponseData {
+async fn get_round_handler(query: web::Query<models::GetRoundDataQueryParams>) -> impl Responder {
+    let mut res_data = models::RoundResponseData {
         data: None,
         round_meta_ptr: None,
         voting_strategy: None,
@@ -153,11 +106,14 @@ async fn get_round_handler(query: web::Query<GetRoundDataQueryParams>) -> impl R
 // use ?project_id=0x01...&{data, project_meta_ptr, project_votes}=true/false
 // multiple params can be used at the same time
 #[get("/project")]
-async fn get_project_handler(query: web::Query<GetProjectDataQueryParams>) -> impl Responder {
-    let mut res_data = ProjectResponseData {
+async fn get_project_handler(
+    query: web::Query<models::GetProjectDataQueryParams>,
+) -> impl Responder {
+    let mut res_data = models::ProjectResponseData {
         data: None,
         project_meta_ptr: None,
         project_votes: None,
+        project_summary: None,
     };
 
     let pg = &mut utils::establish_pg_connection().unwrap();
@@ -191,13 +147,19 @@ async fn get_project_handler(query: web::Query<GetProjectDataQueryParams>) -> im
         }
     }
 
+    if query.project_summary.unwrap_or(false) {
+        let project_summary = utils::summarize_project(pg, project_id.to_string()).await;
+        res_data.project_summary = Some(project_summary);
+        // TODO: check if empty
+    }
+
     HttpResponse::Ok().json(res_data)
 }
 
 // an endpoint for relaying an ipfs query
 // TODO: Investigate caching
 #[get("/ipfs")]
-async fn get_ipfs_handler(query: web::Query<GetIPFSQueryParams>) -> impl Responder {
+async fn get_ipfs_handler(query: web::Query<models::GetIPFSQueryParams>) -> impl Responder {
     let cid = query.cid.clone();
     if cid.is_some() {
         let ipfs_data = utils::fetch_from_ipfs(&cid.unwrap()).await.unwrap();

--- a/src/models.rs
+++ b/src/models.rs
@@ -6,6 +6,7 @@ use crate::schema::{
     project_meta_ptrs, projects, qf_votes, round_meta_ptrs, round_projects_meta_ptrs, rounds,
     voting_strategies,
 };
+use ethers::types::U256;
 
 #[derive(Clone, Insertable, Queryable, Serialize, Deserialize, Debug)]
 #[diesel(table_name = voting_strategies)]
@@ -186,4 +187,62 @@ pub struct RoundProjectsMetaPtr {
     pub id: String,
     pub projectsMetaPtr: MetaPtr,
     pub chainId: Option<u16>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct TokenVote {
+    pub amount: U256,
+    pub token: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ProjectSummary {
+    pub project_id: String,
+    pub round_id: String,
+    pub vote_count: i64,
+    pub unique_voter_count: i64,
+    pub vote_token_sum: Vec<TokenVote>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ProjectResponseData {
+    pub data: Option<ProjectItem>,
+    pub project_meta_ptr: Option<ProjectMetaPtrItem>,
+    pub project_votes: Option<Vec<QfVoteItem>>,
+    pub project_summary: Option<ProjectSummary>,
+}
+
+#[derive(Clone, Deserialize)]
+pub struct GetProjectDataQueryParams {
+    pub project_id: String,
+    pub data: Option<bool>,
+    pub project_meta_ptr: Option<bool>,
+    pub project_votes: Option<bool>,
+    pub project_summary: Option<bool>,
+}
+
+#[derive(Clone, Deserialize, Debug)]
+pub struct GetRoundDataQueryParams {
+    pub round_id: String,
+    pub data: Option<bool>,
+    pub round_meta_ptr: Option<bool>,
+    pub voting_strategy: Option<bool>,
+    pub projects_meta_ptr: Option<bool>,
+    pub round_projects: Option<bool>,
+    pub round_votes: Option<bool>,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct RoundResponseData {
+    pub data: Option<RoundItem>,
+    pub round_meta_ptr: Option<RoundMetaPtrItem>,
+    pub voting_strategy: Option<VotingStrategyItem>,
+    pub projects_meta_ptr: Option<RoundProjectsMetaPtrItem>,
+    pub round_projects: Option<Vec<ProjectItem>>,
+    pub round_votes: Option<Vec<QfVoteItem>>,
+}
+
+#[derive(Deserialize)]
+pub struct GetIPFSQueryParams {
+    pub cid: Option<String>,
 }


### PR DESCRIPTION
fix issue #23 

adds the project_summary boolean flag for the project endpoint. If true - will calculate and return the project summary data. Vote data and project data must exist in the database in order to successfully calculate. 

```shell 
$ curl http://localhost:8080/project\?project_id\=0xc290dd8e51ac35480d9872ce4484aac23bb812c47c0567bfd4beb9113726ed11\&project_summary\=true | jq
```

```shell
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   451  100   451    0     0    291      0  0:00:01  0:00:01 --:--:--   292
{
  "data": null,
  "project_meta_ptr": null,
  "project_votes": null,
  "project_summary": {
    "project_id": "0xc290dd8e51ac35480d9872ce4484aac23bb812c47c0567bfd4beb9113726ed11",
    "round_id": "0xd95a1969c41112cee9a2c931e849bcef36a16f4c",
    "vote_count": 1166,
    "unique_voter_count": 1154,
    "vote_token_sum": [
      {
        "amount": "0x2410c592aceebb8000",
        "token": "0x6b175474e89094c44da98b954eedeac495271d0f"
      },
      {
        "amount": "0x111577b8f0208a9b",
        "token": "0x0000000000000000000000000000000000000000"
      }
    ]
  }
}
```